### PR TITLE
Add Support for Airline API Calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ruby client for the FlightStats Flex API.
 In your Gemfile:
 
 ```ruby
-gem "flightstats-flex", "~> 0.3.0"
+gem "flightstats-flex", "~> 0.4.1"
 ```
 
 or

--- a/lib/flightstats/airline.rb
+++ b/lib/flightstats/airline.rb
@@ -3,8 +3,50 @@ module FlightStats
     attr_accessor :fs,
                   :iata,
                   :icao,
+                  :short_name,
                   :name,
                   :phone_number,
-                  :active
+                  :active,
+                  :category
+  
+    @@base_path = "/flex/airlines/rest/v1/json"
+  
+    class << self
+      def actives(options = {})
+          from_response API.get("#{base_path}/active", {}, options), 'airlines'
+      end
+      
+      def all(options = {})
+        from_response API.get("#{base_path}/all", {}, options), 'airlines'
+      end
+
+      def on_date
+        from_response API.get("#{base_path}/#{year}/#{month}/#{day}", {}, options), 'airlines'
+      end
+      
+      def by_flight_stats_code(flight_stats_code, options = {})
+        from_response API.get("#{base_path}/fs/#{flight_stats_code}", {}, options), 'airline'
+      end
+      
+      def by_iata_code(iata_code, options = {})
+        from_response API.get("#{base_path}/iata/#{iata_code}", {}, options), 'airline'
+      end
+
+      def by_iata_code_on_date(iata_code, year, month, day, options = {})
+        from_response API.get("#{base_path}/iata/#{iata_code}/#{year}/#{month}/#{day}", {}, options), 'airline'
+      end
+
+      def by_icao_code(icao_code, options = {})
+        from_response API.get("#{base_path}/icao/#{icao_code}", {}, options), 'airline'
+      end
+
+      def by_icao_code_on_date(icao_code, year, month, day, options = {})
+        from_response API.get("#{base_path}/icao/#{icao_code}/#{year}/#{month}/#{day}", {}, options), 'airline'
+      end
+      
+      def base_path
+        @@base_path
+      end
+    end
   end
 end

--- a/lib/flightstats/airline.rb
+++ b/lib/flightstats/airline.rb
@@ -29,19 +29,19 @@ module FlightStats
       end
       
       def by_iata_code(iata_code, options = {})
-        from_response API.get("#{base_path}/iata/#{iata_code}", {}, options), 'airline'
+        from_response API.get("#{base_path}/iata/#{iata_code}", {}, options), 'airlines'
       end
 
       def by_iata_code_on_date(iata_code, year, month, day, options = {})
-        from_response API.get("#{base_path}/iata/#{iata_code}/#{year}/#{month}/#{day}", {}, options), 'airline'
+        from_response API.get("#{base_path}/iata/#{iata_code}/#{year}/#{month}/#{day}", {}, options), 'airlines'
       end
 
       def by_icao_code(icao_code, options = {})
-        from_response API.get("#{base_path}/icao/#{icao_code}", {}, options), 'airline'
+        from_response API.get("#{base_path}/icao/#{icao_code}", {}, options), 'airlines'
       end
 
       def by_icao_code_on_date(icao_code, year, month, day, options = {})
-        from_response API.get("#{base_path}/icao/#{icao_code}/#{year}/#{month}/#{day}", {}, options), 'airline'
+        from_response API.get("#{base_path}/icao/#{icao_code}/#{year}/#{month}/#{day}", {}, options), 'airlines'
       end
       
       def base_path

--- a/lib/flightstats/airline.rb
+++ b/lib/flightstats/airline.rb
@@ -20,7 +20,7 @@ module FlightStats
         from_response API.get("#{base_path}/all", {}, options), 'airlines'
       end
 
-      def on_date
+      def on_date(year, month, day, options = {})
         from_response API.get("#{base_path}/#{year}/#{month}/#{day}", {}, options), 'airlines'
       end
       

--- a/lib/flightstats/airline.rb
+++ b/lib/flightstats/airline.rb
@@ -21,7 +21,7 @@ module FlightStats
       end
 
       def on_date(year, month, day, options = {})
-        from_response API.get("#{base_path}/#{year}/#{month}/#{day}", {}, options), 'airlines'
+        from_response API.get("#{base_path}/active/#{year}/#{month}/#{day}", {}, options), 'airlines'
       end
       
       def by_flight_stats_code(flight_stats_code, options = {})

--- a/lib/flightstats/version.rb
+++ b/lib/flightstats/version.rb
@@ -2,7 +2,7 @@ module FlightStats
   module Version
     MAJOR   = 0
     MINOR   = 4
-    PATCH   = 0
+    PATCH   = 1
     PRE     = nil
 
     VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.').freeze


### PR DESCRIPTION
I found that this Gem lacks the Airline API calls from FlightStats. Following the convention of the other classes, I've added filled in FlightStats::Airline to match the appropriate API calls.

If I have time, I'll throw in some rspec tests... Cheers!

I've tested each call manually -- Feel free to merge if it looks good.